### PR TITLE
1.1.0-DEV3

### DIFF
--- a/Server-Core/src/main/java/net/rwhps/server/command/ex/Vote.kt
+++ b/Server-Core/src/main/java/net/rwhps/server/command/ex/Vote.kt
@@ -236,7 +236,7 @@ class Vote {
             commandStartData["gameover"] = { it.normalDistribution() }
             commandStartData["surrender"] = { it.isTeam = true ; it.teamOnly() }
 
-            commandEndData["gameover"] = { Events.fire(EventType.GameOverEvent()) }
+            commandEndData["gameover"] = { Events.fire(EventType.GameOverEvent(null)) }
             commandEndData["surrender"] = { Log.clog("Surrender") ; Data.game.playerManage.playerGroup.eachAllFind({ e: Player -> e.team == it.player.team }) { p: Player -> p.con!!.sendSurrender() } }
         }
 

--- a/Server-Core/src/main/java/net/rwhps/server/command/server/ClientCommands.kt
+++ b/Server-Core/src/main/java/net/rwhps/server/command/server/ClientCommands.kt
@@ -188,8 +188,12 @@ internal class ClientCommands(handler: CommandHandler) {
                 val playerSite = args[0].toInt() - 1
                 val newAdmin = Data.game.playerManage.getPlayerArray(playerSite)
                 if (notIsBlank(newAdmin)) {
+                    if (newAdmin!!.headlessDevice) {
+                        player.sendSystemMessage(player.i18NBundle.getinput("err.player.operating.no"))
+                        return@register
+                    }
                     player.isAdmin = false
-                    newAdmin!!.isAdmin = true
+                    newAdmin.isAdmin = true
                     upDataGameData()
                     sendSystemMessage("give.ok", player.name)
                 } else {
@@ -245,13 +249,14 @@ internal class ClientCommands(handler: CommandHandler) {
                     player.sendSystemMessage(player.i18NBundle.getinput("err.noNumber"))
                     return@register
                 }
-                if (args[0].toInt()  == Data.config.MaxPlayer+1) {
-                    player.sendSystemMessage(player.i18NBundle.getinput("err.player.operating.no"))
-                    return@register
-                }
+
                 val site = args[0].toInt() - 1
                 val kickPlayer = Data.game.playerManage.getPlayerArray(site)
                 if (kickPlayer != null) {
+                    if (kickPlayer.headlessDevice) {
+                        player.sendSystemMessage(player.i18NBundle.getinput("err.player.operating.no"))
+                        return@register
+                    }
                     try {
                         kickPlayer.kickPlayer(localeUtil.getinput("kick.you"),60)
                     } catch (e: IOException) {
@@ -296,7 +301,7 @@ internal class ClientCommands(handler: CommandHandler) {
                     player.sendSystemMessage(player.i18NBundle.getinput("err.noStartGame"))
                     return@register
                 }
-                Data.game.gamePaused = false
+                Data.game.gamePaused = true
                 Call.sendSystemMessage(player.i18NBundle.getinput("unpause.ok"))
             }
         }
@@ -443,8 +448,8 @@ internal class ClientCommands(handler: CommandHandler) {
                     Data.game.playerManage.playerGroup.eachAll { it.sharedControl = true }
                 }
                 Data.game.playerManage.updateControlIdentifier()
-                testPreparationPlayer()
                 Events.fire(GameStartEvent())
+                testPreparationPlayer()
             }
         }
         handler.register("t", "<text...>", "clientCommands.t") { args: Array<String>, player: Player ->

--- a/Server-Core/src/main/java/net/rwhps/server/command/server/ServerCommands.kt
+++ b/Server-Core/src/main/java/net/rwhps/server/command/server/ServerCommands.kt
@@ -54,7 +54,7 @@ internal class ServerCommands(handler: CommandHandler) {
             sendSystemMessage(response.toString().replace("<>", ""))
         }
         handler.register("gameover", "serverCommands.gameover") { _: Array<String>?, _: StrCons ->
-            Events.fire(GameOverEvent())
+            Events.fire(GameOverEvent(null))
         }
         handler.register("admin", "<add/remove> <PlayerPosition> [SpecialPermissions]", "serverCommands.admin") { arg: Array<String>, log: StrCons ->
             if (Data.game.isStartGame) {

--- a/Server-Core/src/main/java/net/rwhps/server/core/Application.kt
+++ b/Server-Core/src/main/java/net/rwhps/server/core/Application.kt
@@ -17,10 +17,12 @@ import net.rwhps.server.data.plugin.PluginManage.runOnDisable
 import net.rwhps.server.net.Administration
 import net.rwhps.server.util.IsUtil.isBlank
 import net.rwhps.server.util.RandomUtil.getRandomString
+import net.rwhps.server.util.encryption.digest.DigestUtil
 import net.rwhps.server.util.file.FileUtil
 import net.rwhps.server.util.log.Log
 import net.rwhps.server.util.log.Log.error
 import java.lang.management.ManagementFactory
+import java.math.BigInteger
 import java.util.*
 
 
@@ -33,6 +35,9 @@ class Application {
 
     /** 服务器唯一UUID  */
     lateinit var serverConnectUuid: String
+    /** Hess HEX */
+    lateinit var serverHessUuid: String
+
     @JvmField
     var serverToken: String = getRandomString(40)
     lateinit var admin: Administration
@@ -49,8 +54,11 @@ class Application {
         Initialization.startInit(settings)
 
         serverConnectUuid = settings.getData("serverConnectUuid") { UUID.randomUUID().toString() }
+        serverHessUuid = settings.getData("serverHessUuid") { BigInteger(1, DigestUtil.sha256(serverConnectUuid+UUID.randomUUID().toString())).toString(16).uppercase() }
+
         addSavePool {
             settings.setData("serverConnectUuid", serverConnectUuid)
+            settings.setData("serverHessUuid", serverHessUuid)
         }
     }
 

--- a/Server-Core/src/main/java/net/rwhps/server/core/Call.kt
+++ b/Server-Core/src/main/java/net/rwhps/server/core/Call.kt
@@ -14,11 +14,13 @@ import net.rwhps.server.core.thread.Threads
 import net.rwhps.server.core.thread.Threads.newCountdown
 import net.rwhps.server.core.thread.TimeTaskData
 import net.rwhps.server.data.HessModuleManage
+import net.rwhps.server.data.event.GameOverData
 import net.rwhps.server.data.global.Data
 import net.rwhps.server.data.global.NetStaticData
 import net.rwhps.server.data.player.Player
 import net.rwhps.server.game.event.EventType.GameOverEvent
 import net.rwhps.server.io.packet.GameCommandPacket
+import net.rwhps.server.struct.ObjectMap
 import net.rwhps.server.struct.Seq
 import net.rwhps.server.util.Time
 import net.rwhps.server.util.game.Events
@@ -245,21 +247,36 @@ object Call {
         init {
             Threads.newTimedTask(CallTimeTask.AutoCheckTask,0,1,TimeUnit.SECONDS) {
                 var lastWinTeam: Int = -1
-                var lastWinCount = 90
+                var lastWinCount = 0
                 Data.game.playerManage.runPlayerArrayDataRunnable(true) {
-                    if (it == null) {
-                        return@runPlayerArrayDataRunnable
-                    }
-                    if (it.survive && it.team != lastWinTeam) {
-                        lastWinTeam = it.team
-                        lastWinCount++
+                    if (it != null) {
+                        if (it.survive && it.team != lastWinTeam) {
+                            lastWinTeam = it.team
+                            lastWinCount++
+                        }
                     }
                 }
                 if (lastWinCount == 1) {
-                    val last = Data.game.playerManage.getPlayersNameOnTheSameTeam(lastWinTeam).toArray(String::class.java).contentToString()
+                    Threads.closeTimeTask(CallTimeTask.AutoCheckTask)
+
+                    val winPlayer = Data.game.playerManage.getPlayersNameOnTheSameTeam(lastWinTeam)
+                    val allPlayer = Seq<String>()
+
+                    val statusData = ObjectMap<String, ObjectMap<String,Int>>().apply {
+                        Data.game.playerManage.playerAll.eachAllFind({ !it.headlessDevice }) {
+                            put(it.name,it.statusData)
+                            allPlayer.add(it.name)
+                        }
+                    }
+
+                    Data.game.gameOverData = GameOverData(
+                        allPlayer, winPlayer, Data.game.maps.mapName,
+                        statusData, Data.game.replayName
+                    )
+
+                    val last = winPlayer.toArray(String::class.java).contentToString()
                     Log.clog("Last Win Player: {0}",last)
                     sendSystemMessageLocal("survive.player",last)
-                    Threads.closeTimeTask(CallTimeTask.AutoCheckTask)
                 }
                 Data.game.playerManage.updateControlIdentifier()
             }
@@ -269,8 +286,8 @@ object Call {
             // 检测人数是否符合Gameover
 
             when (Data.game.playerManage.playerGroup.size) {
-                0 -> gr()
-                1,2 -> if (oneSay) {
+                1 -> gr()
+                2 -> if (oneSay) {
                     oneSay = false
                     sendSystemMessageLocal("gameOver.oneMin")
                     newCountdown(CallTimeTask.GameOverTask, 1, TimeUnit.MINUTES) {gr()}
@@ -338,7 +355,7 @@ object Call {
             cancel()
             TimeTaskData.stopCallTickTask()
 
-            Events.fire(GameOverEvent())
+            Events.fire(GameOverEvent(Data.game.gameOverData))
         }
     }
 }

--- a/Server-Core/src/main/java/net/rwhps/server/core/Call.kt
+++ b/Server-Core/src/main/java/net/rwhps/server/core/Call.kt
@@ -286,8 +286,8 @@ object Call {
             // 检测人数是否符合Gameover
 
             when (Data.game.playerManage.playerGroup.size) {
-                1 -> gr()
-                2 -> if (oneSay) {
+                0 -> gr()
+                1,2 -> if (oneSay) {
                     oneSay = false
                     sendSystemMessageLocal("gameOver.oneMin")
                     newCountdown(CallTimeTask.GameOverTask, 1, TimeUnit.MINUTES) {gr()}

--- a/Server-Core/src/main/java/net/rwhps/server/custom/LoadCoreCustomPlugin.kt
+++ b/Server-Core/src/main/java/net/rwhps/server/custom/LoadCoreCustomPlugin.kt
@@ -12,6 +12,7 @@ package net.rwhps.server.custom
 import net.rwhps.server.data.plugin.PluginManage
 import net.rwhps.server.plugin.beta.MoreMain
 import net.rwhps.server.plugin.beta.UpListMain
+import net.rwhps.server.plugin.beta.WinTestMain
 import net.rwhps.server.plugin.beta.httpapi.ApiMain
 import net.rwhps.server.plugin.beta.noattack.ConnectionLimit
 
@@ -31,7 +32,7 @@ internal class LoadCoreCustomPlugin {
         PluginManage.addPluginClass("UpList","Dr","$core UpList","1.0", UpListMain(), mkdir = false, skip = true)
         PluginManage.addPluginClass("ConnectionLimit","Dr","$coreEx ConnectionLimit","1.0", ConnectionLimit(), mkdir = false, skip = true)
         PluginManage.addPluginClass("TwoHessTest","Dr","$example TwoHessTest","1.0", MoreMain(), mkdir = false, skip = true)
-
+        PluginManage.addPluginClass("WinTest","Dr","$example WinTest","1.0", WinTestMain(), mkdir = false, skip = true)
         PluginManage.addPluginClass("HttpApi", "zhou2008", "$coreEx HttpApi", "1.0", ApiMain(), mkdir = true, skip = true)
     }
 }

--- a/Server-Core/src/main/java/net/rwhps/server/data/event/GameOverData.kt
+++ b/Server-Core/src/main/java/net/rwhps/server/data/event/GameOverData.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2020-2023 RW-HPS Team and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license that can be found through the following link.
+ *
+ * https://github.com/RW-HPS/RW-HPS/blob/master/LICENSE
+ */
+
+package net.rwhps.server.data.event
+
+import net.rwhps.server.struct.ObjectMap
+import net.rwhps.server.struct.Seq
+
+data class GameOverData(
+    val allPlayerList: Seq<String>,
+    val winPlayerList: Seq<String>,
+    val mapName: String,
+    val playerData: ObjectMap<String,ObjectMap<String,Int>>,
+    val replayName: String
+)

--- a/Server-Core/src/main/java/net/rwhps/server/data/global/Data.kt
+++ b/Server-Core/src/main/java/net/rwhps/server/data/global/Data.kt
@@ -33,12 +33,13 @@ object Data {
     const val Plugin_Save_Path = "/data/save"
     const val Plugin_Cache_Path = "/data/cache"
     const val Plugin_Lib_Path = "/data/libs"
-    const val Plugin_GameCore_Data_Path = "/data/gameData"
-    const val Plugin_GameCore_Lib_Path = "$Plugin_GameCore_Data_Path/coreLibs"
     const val Plugin_Log_Path = "/data/log"
     const val Plugin_Maps_Path = "/data/maps"
     const val Plugin_Plugins_Path = "/data/plugins"
+
+    const val Plugin_GameCore_Data_Path = "/data/gameData"
     const val Plugin_Mods_Path = "/data/mods"
+    const val Plugin_RePlays_Path = "/data/replays"
     val UTF_8: Charset = StandardCharsets.UTF_8
     /*
 	 * 插件默认变量
@@ -47,7 +48,7 @@ object Data {
     const val SERVER_ID = "net.rwhps.server"
     const val SERVER_ID_RELAY = "net.rwhps.server.relayCustomMode.Dr"
     const val SERVER_ID_RELAY_GET = "net.rwhps.server.relayGetUUIDHex.Dr"
-    const val SERVER_CORE_VERSION = "1.1.0-DEV2"
+    const val SERVER_CORE_VERSION = "1.1.0-DEV3"
     const val TOPT_KEY = "net.rwhps.server.topt # RW-HPS Team"
     const val SERVER_RELAY_UUID = "RCN Team & Tiexiu.xyz Core Team"
     /** 单位数据缓存  */

--- a/Server-Core/src/main/java/net/rwhps/server/data/player/Player.kt
+++ b/Server-Core/src/main/java/net/rwhps/server/data/player/Player.kt
@@ -13,7 +13,6 @@ import net.rwhps.server.data.HessModuleManage
 import net.rwhps.server.data.global.Data
 import net.rwhps.server.data.global.NetStaticData
 import net.rwhps.server.data.plugin.Value
-import net.rwhps.server.data.totalizer.TimeAndNumber
 import net.rwhps.server.func.Prov
 import net.rwhps.server.game.simulation.core.AbstractPlayerData
 import net.rwhps.server.net.core.IRwHps
@@ -42,6 +41,8 @@ class Player(
     @JvmField val i18NBundle: I18NBundle,
 ) {
     internal var playerPrivateData: AbstractPlayerData = HessModuleManage.hps.gameData.getDefPlayerData()
+
+    var headlessDevice = checkHess(uuid)
 
     /** is Admin  */
 	@JvmField
@@ -77,6 +78,15 @@ class Player(
     val buildingsLost get() = playerPrivateData.buildingsLost
     /** 单实验单位被击杀数 */
     val experimentalsLost get() = playerPrivateData.experimentalsLost
+
+    val statusData get() = ObjectMap<String,Int>().apply {
+            put("unitsKilled", unitsKilled)
+            put("buildingsKilled", buildingsKilled)
+            put("experimentalsKilled", experimentalsKilled)
+            put("unitsLost", unitsLost)
+            put("buildingsLost", buildingsLost)
+            put("experimentalsLost", experimentalsLost)
+        }
 
     /** */
     var startUnit = Data.game.initUnit
@@ -118,8 +128,6 @@ class Player(
         }
 
     var lastVoteTime: Int = 0
-
-    val reConnectData = TimeAndNumber(300,3)
 
     private val customData = ObjectMap<String, Value<*>>()
 
@@ -242,5 +250,12 @@ class Player(
 
     override fun hashCode(): Int {
         return Objects.hash(uuid)
+    }
+
+    companion object {
+        @JvmStatic
+        fun checkHess(uuid: String): Boolean {
+            return uuid == Data.core.serverHessUuid
+        }
     }
 }

--- a/Server-Core/src/main/java/net/rwhps/server/data/player/PlayerManage.kt
+++ b/Server-Core/src/main/java/net/rwhps/server/data/player/PlayerManage.kt
@@ -55,7 +55,7 @@ class PlayerManage(private val maxPlayerSize: Int) {
     fun addPlayer(con: GameVersionServer, uuid: String, name: String, i18NBundle: I18NBundle = Data.i18NBundle): Player {
         val player = Player(con, uuid, name, i18NBundle)
         if (Data.config.OneAdmin) {
-            if ((playerGroup.size == 0 && name != Data.headlessName) || (containsName(Data.headlessName) != null && playerGroup.size == 1)) {
+            if (!player.headlessDevice && playerGroup.size == 1) {
                 player.isAdmin = true
             }
         }
@@ -99,10 +99,9 @@ class PlayerManage(private val maxPlayerSize: Int) {
         return null
     }
 
-
     fun runPlayerArrayDataRunnable(skipHd: Boolean = false, run: (Player?) -> Unit) {
         for (player in playerData) {
-            if (player != null && player.name == Data.headlessName && skipHd) {
+            if (player != null && player.headlessDevice && skipHd) {
                 // S K I P
             } else {
                 run(player)
@@ -151,7 +150,7 @@ class PlayerManage(private val maxPlayerSize: Int) {
 
     private fun autoPlayerTeam(player: Player) {
         moveLock.withLock {
-            if (player.name == Data.headlessName) {
+            if (player.headlessDevice) {
                 playerData[Data.config.MaxPlayer] = player
                 player.site = Data.config.MaxPlayer
                 player.team = -3

--- a/Server-Core/src/main/java/net/rwhps/server/data/plugin/AbstractPluginData.kt
+++ b/Server-Core/src/main/java/net/rwhps/server/data/plugin/AbstractPluginData.kt
@@ -60,7 +60,7 @@ internal open class AbstractPluginData {
         if (SERIALIZERS.containsKey(T::class.java)) {
             pluginData.put(name, Value(data))
         } else {
-            throw VariableException.ObjectMapRuntimeException("UNSUPPORTED_SERIALIZATION")
+            throw VariableException.ObjectMapRuntimeException("${T::class.java} : UNSUPPORTED_SERIALIZATION")
         }
     }
 
@@ -120,7 +120,7 @@ internal open class AbstractPluginData {
                         4 -> pluginData.put(key, Value(stream.readUTF()))
                         5 -> {
                             /* 把String转为Class,来进行反序列化 */
-                            val classCache: Class<*> = Class.forName(stream.readUTF().replace("cn.rwhps.server", "net.rwhps.server"))
+                            val classCache: Class<*> = Class.forName(stream.readUTF().replace("net.rwhps.server", "net.rwhps.server"))
                             length = stream.readInt()
                             bytes = ByteArray(length)
                             stream.read(bytes)
@@ -139,12 +139,13 @@ internal open class AbstractPluginData {
         }
     }
 
-    fun save() {
+    @JvmOverloads
+    fun save(outputStream: OutputStream = fileUtil!!.writeByteOutputStream(false)) {
         if (isBlank(fileUtil) || fileUtil!!.notExists()) {
             return
         }
         try {
-            DataOutputStream(getGzipOutputStream(fileUtil!!.writeByteOutputStream(false))).use { stream ->
+            DataOutputStream(getGzipOutputStream(outputStream)).use { stream ->
                 stream.writeInt(pluginData.size)
                 for (entry in pluginData) {
                     stream.writeUTF(entry.key)

--- a/Server-Core/src/main/java/net/rwhps/server/data/plugin/DefaultSerializers.kt
+++ b/Server-Core/src/main/java/net/rwhps/server/data/plugin/DefaultSerializers.kt
@@ -9,6 +9,7 @@
 
 package net.rwhps.server.data.plugin
 
+import net.rwhps.server.custom.RCNBind
 import net.rwhps.server.io.GameInputStream
 import net.rwhps.server.io.GameOutputStream
 import net.rwhps.server.io.packet.Packet
@@ -86,6 +87,17 @@ internal object DefaultSerializers {
             @Throws(IOException::class)
             override fun read(stream: GameInputStream): Boolean {
                 return stream.readBoolean()
+            }
+        })
+        AbstractPluginData.setSerializer(ByteArray::class.java, object : TypeSerializer<ByteArray> {
+            @Throws(IOException::class)
+            override fun write(stream: GameOutputStream, objectData: ByteArray) {
+                stream.writeBytesAndLength(objectData)
+            }
+
+            @Throws(IOException::class)
+            override fun read(stream: GameInputStream): ByteArray {
+                return stream.readStreamBytes()
             }
         })
     }
@@ -219,6 +231,7 @@ internal object DefaultSerializers {
 
         AbstractPluginData.setSerializer(Packet::class.java, Packet.serializer)
         AbstractPluginData.setSerializer(NetConnectProofOfWork::class.java, NetConnectProofOfWork.serializer)
+        AbstractPluginData.setSerializer(RCNBind.BindData::class.java, RCNBind.serializer)
     }
 
     @Throws(ClassNotFoundException::class)

--- a/Server-Core/src/main/java/net/rwhps/server/data/plugin/DefaultSerializers.kt
+++ b/Server-Core/src/main/java/net/rwhps/server/data/plugin/DefaultSerializers.kt
@@ -9,7 +9,6 @@
 
 package net.rwhps.server.data.plugin
 
-import net.rwhps.server.custom.RCNBind
 import net.rwhps.server.io.GameInputStream
 import net.rwhps.server.io.GameOutputStream
 import net.rwhps.server.io.packet.Packet
@@ -231,7 +230,6 @@ internal object DefaultSerializers {
 
         AbstractPluginData.setSerializer(Packet::class.java, Packet.serializer)
         AbstractPluginData.setSerializer(NetConnectProofOfWork::class.java, NetConnectProofOfWork.serializer)
-        AbstractPluginData.setSerializer(RCNBind.BindData::class.java, RCNBind.serializer)
     }
 
     @Throws(ClassNotFoundException::class)

--- a/Server-Core/src/main/java/net/rwhps/server/data/plugin/PluginEventManage.kt
+++ b/Server-Core/src/main/java/net/rwhps/server/data/plugin/PluginEventManage.kt
@@ -83,13 +83,11 @@ internal class PluginEventManage {
                 pluginEventData.eachAll(AbstractEvent::registerGameStartEvent)
             }
             /* Sync */
-            Events.on(HessStartEvent::class.java) { _: HessStartEvent? ->
-                pluginEventData.eachAll(AbstractEvent::registerHessStartEvent)
-            }
-            /* Sync */
-            Events.on(GameOverEvent::class.java) { _: GameOverEvent? ->
+            Events.on(GameOverEvent::class.java) { e: GameOverEvent ->
                 if (Data.game.isGameover) {
-                    pluginEventData.eachAll(AbstractEvent::registerGameOverEvent)
+                    pluginEventData.eachAll { p: AbstractEvent ->
+                        p.registerGameOverEvent(e.gameOverData)
+                    }
                 }
             }
             /* ASync */

--- a/Server-Core/src/main/java/net/rwhps/server/dependent/redirections/game/CustomRedirections.kt
+++ b/Server-Core/src/main/java/net/rwhps/server/dependent/redirections/game/CustomRedirections.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2020-2023 RW-HPS Team and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license that can be found through the following link.
+ *
+ * https://github.com/RW-HPS/RW-HPS/blob/master/LICENSE
+ */
+
+package net.rwhps.server.dependent.redirections.game
+
+import net.rwhps.server.data.global.Data
+import net.rwhps.server.dependent.redirections.MainRedirections
+
+class CustomRedirections : MainRedirections {
+    override fun register() {
+        redirect("com/corrodinggames/rts/gameFramework/j/ad", arrayOf("Z","()Ljava/lang/String;")) { obj: Any, _: String?, _: Class<*>?, _: Array<Any?>? ->
+            return@redirect Data.core.serverHessUuid
+        }
+    }
+}

--- a/Server-Core/src/main/java/net/rwhps/server/dependent/redirections/game/FileLoaderRedirections.kt
+++ b/Server-Core/src/main/java/net/rwhps/server/dependent/redirections/game/FileLoaderRedirections.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright 2020-2023 RW-HPS Team and contributors.
- *  
+ *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license that can be found through the following link.
  *

--- a/Server-Core/src/main/java/net/rwhps/server/dependent/redirections/game/IteratorSecurityRedirections.kt
+++ b/Server-Core/src/main/java/net/rwhps/server/dependent/redirections/game/IteratorSecurityRedirections.kt
@@ -14,6 +14,7 @@ import net.rwhps.server.util.inline.accessibleConstructor
 import net.rwhps.server.util.inline.findMethod
 import net.rwhps.server.util.inline.toClassAutoLoader
 
+@Deprecated("影响效率")
 class IteratorSecurityRedirections : MainRedirections {
     override fun register() {
         val listName = "com.corrodinggames.rts.gameFramework.utility.s"

--- a/Server-Core/src/main/java/net/rwhps/server/dependent/redirections/lwjgl/LwjglRedirections.kt
+++ b/Server-Core/src/main/java/net/rwhps/server/dependent/redirections/lwjgl/LwjglRedirections.kt
@@ -27,6 +27,7 @@ class LwjglRedirections : MainRedirections {
         redirect(AppGameContainerUpdate.DESC, AppGameContainerUpdate())
 
         redirect("Lorg/lwjgl/opengl/Display;isCreated()Z", Redirection.of(true))
+        redirect("Lorg/lwjgl/opengl/Display;isVisible()Z", Redirection.of(true))
         redirect("Lorg/lwjgl/glfw/GLFW;glfwWaitEventsTimeout(D)V") { _: Any?, _: String?, _: Class<*>?, args: Array<Any> ->
             Thread.sleep((args[0] as Double * 1000L).toLong())
             null

--- a/Server-Core/src/main/java/net/rwhps/server/dependent/redirections/slick/AppGameContainerUpdate.kt
+++ b/Server-Core/src/main/java/net/rwhps/server/dependent/redirections/slick/AppGameContainerUpdate.kt
@@ -53,9 +53,9 @@ class AppGameContainerUpdate @JvmOverloads constructor(private val time: Long = 
             return try {
                 // 经过测试 最佳的 sleep 是比 游戏Tick 稍快
                 // 但是存在问题 例如玩家刚进入 就开始游戏 那么数据将来不及更新导致错误
-                System.getProperty(LwjglClassProperties.AppGameContainer_UPDATE, "5").toLong()
+                System.getProperty(LwjglClassProperties.AppGameContainer_UPDATE, "10").toLong()
             } catch (nfe: NumberFormatException) {
-                5L
+                10L
             }
         }
     }

--- a/Server-Core/src/main/java/net/rwhps/server/dependent/redirections/slick/SlickRedirections.kt
+++ b/Server-Core/src/main/java/net/rwhps/server/dependent/redirections/slick/SlickRedirections.kt
@@ -15,7 +15,10 @@ import net.rwhps.server.dependent.redirections.MainRedirections
 import net.rwhps.server.util.GameModularLoadClass
 import net.rwhps.server.util.alone.annotations.AsmMark
 import net.rwhps.server.util.alone.annotations.NeedHelp
-import net.rwhps.server.util.inline.*
+import net.rwhps.server.util.inline.accessibleConstructor
+import net.rwhps.server.util.inline.findMethod
+import net.rwhps.server.util.inline.readAsClassBytes
+import net.rwhps.server.util.inline.toClass
 
 @NeedHelp
 @AsmMark.ClassLoaderCompatible

--- a/Server-Core/src/main/java/net/rwhps/server/game/Event.kt
+++ b/Server-Core/src/main/java/net/rwhps/server/game/Event.kt
@@ -13,7 +13,7 @@ import net.rwhps.server.core.Call
 import net.rwhps.server.core.NetServer
 import net.rwhps.server.core.thread.CallTimeTask
 import net.rwhps.server.core.thread.Threads
-import net.rwhps.server.data.HessModuleManage
+import net.rwhps.server.data.event.GameOverData
 import net.rwhps.server.data.global.Data
 import net.rwhps.server.data.global.NetStaticData
 import net.rwhps.server.data.player.Player
@@ -35,10 +35,6 @@ class Event : AbstractEvent {
     override fun registerPlayerJoinEvent(player: Player) {
         if (player.name.isBlank() || player.name.length > 30) {
             player.kickPlayer(player.getinput("kick.name.failed"))
-            return
-        }
-        if (HessModuleManage.hps.gameData.checkHess(player.name)) {
-            player.kickPlayer("Forbidden name")
             return
         }
 
@@ -157,7 +153,7 @@ class Event : AbstractEvent {
         Log.clog("[Start New Game]")
     }
 
-    override fun registerGameOverEvent() {
+    override fun registerGameOverEvent(gameOverData: GameOverData?) {
         if (Data.game.maps.mapData != null) {
             Data.game.maps.mapData!!.clean()
         }

--- a/Server-Core/src/main/java/net/rwhps/server/game/Rules.kt
+++ b/Server-Core/src/main/java/net/rwhps/server/game/Rules.kt
@@ -12,6 +12,7 @@ import net.rwhps.server.core.thread.CallTimeTask
 import net.rwhps.server.core.thread.Threads
 import net.rwhps.server.core.thread.Threads.newTimedTask
 import net.rwhps.server.data.base.BaseConfig
+import net.rwhps.server.data.event.GameOverData
 import net.rwhps.server.data.global.Data
 import net.rwhps.server.data.global.NetStaticData
 import net.rwhps.server.data.player.PlayerManage
@@ -113,6 +114,12 @@ class Rules(private var config: BaseConfig) {
     val tickGame = AtomicInteger(10)
     var isGameover = false
 
+    var replayName: String = ""
+        set(value) {
+            field = value.trim()
+        }
+    var gameOverData: GameOverData? = null
+
     init {
         try {
             checkMaps()
@@ -166,6 +173,8 @@ class Rules(private var config: BaseConfig) {
 
         gameReConnectPaused = false
         gamePaused = false
+
+        gameOverData = null
     }
 
     fun checkMaps() {

--- a/Server-Core/src/main/java/net/rwhps/server/game/event/EventType.kt
+++ b/Server-Core/src/main/java/net/rwhps/server/game/event/EventType.kt
@@ -9,6 +9,7 @@
 
 package net.rwhps.server.game.event
 
+import net.rwhps.server.data.event.GameOverData
 import net.rwhps.server.data.player.Player
 
 /**
@@ -32,11 +33,9 @@ class EventType {
 
     /** 开始游戏  */
     class GameStartEvent
-    /** 无头开始游戏  */
-    class HessStartEvent()
 
     /** 结束游戏  */
-    class GameOverEvent
+    class GameOverEvent(val gameOverData: GameOverData?)
 
     /** 玩家被ban  */
     class PlayerBanEvent(val player: Player)

--- a/Server-Core/src/main/java/net/rwhps/server/game/simulation/GameHeadlessEvent.kt
+++ b/Server-Core/src/main/java/net/rwhps/server/game/simulation/GameHeadlessEvent.kt
@@ -13,6 +13,7 @@ import net.rwhps.server.core.Call
 import net.rwhps.server.core.thread.CallTimeTask
 import net.rwhps.server.core.thread.Threads
 import net.rwhps.server.data.HessModuleManage
+import net.rwhps.server.data.event.GameOverData
 import net.rwhps.server.data.global.Data
 import net.rwhps.server.plugin.event.AbstractEvent
 import net.rwhps.server.util.log.Log
@@ -20,10 +21,14 @@ import java.util.concurrent.TimeUnit
 
 class GameHeadlessEvent : AbstractEvent {
     override fun registerGameStartEvent() {
+        Data.game.playerManage.playerAll.eachAll { player ->
+            player.playerPrivateData = HessModuleManage.hps.gameData.getPlayerData(player.site)
+        }
+
         Threads.newTimedTask(CallTimeTask.CallCheckTask,0,2, TimeUnit.SECONDS,Call::sendCheckData)
     }
 
-    override fun registerGameOverEvent() {
+    override fun registerGameOverEvent(gameOverData: GameOverData?) {
         Threads.closeTimeTask(CallTimeTask.CallCheckTask)
         Log.debug("Stop CallCheckTask")
 
@@ -33,11 +38,5 @@ class GameHeadlessEvent : AbstractEvent {
         Log.clog("Stop GameHeadless")
         HessModuleManage.hps.gameNet.newConnect()
         Log.clog("ReRun GameHeadless")
-    }
-
-    override fun registerHessStartEvent() {
-        Data.game.playerManage.playerAll.eachAll { player ->
-            player.playerPrivateData = HessModuleManage.hps.gameData.getPlayerData(player.site)
-        }
     }
 }

--- a/Server-Core/src/main/java/net/rwhps/server/game/simulation/core/AbstractGameData.kt
+++ b/Server-Core/src/main/java/net/rwhps/server/game/simulation/core/AbstractGameData.kt
@@ -14,8 +14,6 @@ import net.rwhps.server.util.alone.annotations.GameSimulationLayer
 import net.rwhps.server.util.log.exp.ImplementedException
 
 interface AbstractGameData {
-    fun checkHess(name: String): Boolean
-
     @GameSimulationLayer.GameSimulationLayer_KeyWords("gameSave")
     fun getGameData(): Packet
 

--- a/Server-Core/src/main/java/net/rwhps/server/game/simulation/gameFramework/GameData.kt
+++ b/Server-Core/src/main/java/net/rwhps/server/game/simulation/gameFramework/GameData.kt
@@ -9,10 +9,15 @@
 
 package net.rwhps.server.game.simulation.gameFramework
 
+import com.corrodinggames.rts.game.a.a
+import com.corrodinggames.rts.game.c
+import com.corrodinggames.rts.game.f
 import com.corrodinggames.rts.game.n
 import com.corrodinggames.rts.game.units.am
+import com.corrodinggames.rts.game.units.ar
 import com.corrodinggames.rts.gameFramework.j.al
 import com.corrodinggames.rts.gameFramework.l
+import com.corrodinggames.rts.gameFramework.w
 import net.rwhps.server.data.global.Data
 import net.rwhps.server.data.global.NetStaticData
 import net.rwhps.server.game.simulation.core.AbstractGameData
@@ -22,15 +27,15 @@ import net.rwhps.server.io.packet.Packet
 import net.rwhps.server.net.core.IRwHps
 import net.rwhps.server.util.PacketType
 import net.rwhps.server.util.WaitResultUtil
+import net.rwhps.server.util.inline.findField
+import net.rwhps.server.util.inline.toClassAutoLoader
 import net.rwhps.server.util.log.Log
 import net.rwhps.server.util.log.exp.ImplementedException
+import java.io.IOException
 import com.corrodinggames.rts.gameFramework.j.`as` as GameNetOutStream
 
-internal class GameData : AbstractGameData {
-    override fun checkHess(name: String): Boolean {
-        return (name == Data.headlessName && Data.game.playerManage.playerGroup.size > 1)
-    }
 
+internal class GameData : AbstractGameData {
     override fun getGameData(): Packet {
         val gameEngine: l = GameEngine.gameEngine
         val arVar = GameNetOutStream()
@@ -42,7 +47,7 @@ internal class GameData : AbstractGameData {
         arVar.a(false)
         arVar.a(false)
         arVar.e("gameSave")
-        gameEngine.ca.a(arVar)
+        wirteGameRsyncData(arVar)
         arVar.a("gameSave")
         return Packet(35,arVar.b(35).c)
     }
@@ -74,7 +79,7 @@ internal class GameData : AbstractGameData {
                 stream.getDecodeStream(false).use { checkList ->
                     checkList.readInt()
                     if (checkList.readInt() != GameEngine.netEngine.am.b.size) {
-                        Log.debug("RustedWarfare", "checkSumSize!=syncCheckList.size()");
+                        Log.debug("RustedWarfare", "checkSumSize!=syncCheckList.size()")
                     }
                     val checkTypeList: ArrayList<al> = GameEngine.netEngine.am.b as ArrayList<al>
                     for (checkType in checkTypeList) {
@@ -82,12 +87,12 @@ internal class GameData : AbstractGameData {
                         val client = checkList.readLong()
                         if (server != client) {
                             syncFlag = true
-                            Log.debug("RustedWarfare", "CheckType: ${checkType.a} Checksum: $syncTick Server: $server Client: $client");
+                            Log.debug("RustedWarfare", "CheckType: ${checkType.a} Checksum: $syncTick Server: $server Client: $client")
                         }
                         val tickServer = Data.game.tickGame.get()
                         if (tickServer >= syncTick) {
-                            Log.debug("RustedWarfare", "Not marking desync, already resynced before tick: $tickServer <= $tick");
-                            return false;
+                            Log.debug("RustedWarfare", "Not marking desync, already resynced before tick: $tickServer <= $tick")
+                            return false
                         }
 
                     }
@@ -168,5 +173,124 @@ internal class GameData : AbstractGameData {
         override val experimentalsLost get() = error()
 
         override var credits: Int = 0
+    }
+
+    private fun wirteGameRsyncData(asVar: GameNetOutStream) {
+        val B = GameEngine.gameEngine
+        try {
+            asVar.c("rustedWarfareSave")
+            asVar.a(B.c(true))
+            asVar.a(96)
+            asVar.a(B.ar)
+            asVar.a("saveCompression", true)
+            asVar.e("customUnitsBlock")
+            com.corrodinggames.rts.game.units.custom.l.a(asVar)
+            asVar.a("customUnitsBlock")
+            asVar.e("gameSetup")
+            val z = B.bX.B || B.bX.F
+            asVar.a(B.bX.B)
+            asVar.a(B.bX.F)
+            asVar.a(z)
+            if (z) {
+                B.bX.a(asVar)
+            }
+            asVar.a("gameSetup")
+            asVar.c(B.dl)
+            val z2 = B.dm != null
+            asVar.a(z2)
+            if (z2) {
+                // Writing remote map steam into save
+                asVar.a(B.dm)
+            }
+            asVar.a(B.by)
+            asVar.a(B.cy + B.cI)
+            asVar.a(B.cz + B.cJ)
+            asVar.a(B.cV)
+            asVar.a("com.corrodinggames.rts.gameFramework.aa".toClassAutoLoader(this)!!
+                .findField("a",Int::class.java)!!.get(B.bV) as Int
+            )
+            asVar.a(0)
+            asVar.e()
+            B.bL.a(asVar)
+            asVar.a(B.bv)
+            asVar.a(B.bL.E)
+            asVar.a(B.bL.F)
+            asVar.a(B.bL.G)
+            asVar.a(B.ce != null)
+            if (B.ce != null) {
+                B.ce.a(asVar)
+            }
+            asVar.e()
+            var i = -1
+            if (B.bs != null) {
+                i = B.bs.k
+            }
+            asVar.a(i)
+            asVar.a(n.c)
+            for (i2 in 0 until n.c) {
+                val k = n.k(i2)
+                asVar.a(k is a)
+                asVar.a(k is c)
+                asVar.a(k != null)
+                k?.b(asVar)
+            }
+
+            // Section: unit shells
+            val er = (w.er.clone() as com.corrodinggames.rts.gameFramework.utility.s)
+            asVar.a(er.size)
+            val it: Iterator<*> = er.iterator()
+            while (it.hasNext()) {
+                val wVar: w = it.next() as w? ?: throw RuntimeException("Found null in fastGameObjectList")
+                if (wVar is am) {
+                    val amVar = wVar
+                    if (amVar.r() is ar) {
+                        asVar.c(1)
+                        asVar.a(amVar.r() as ar as Enum<*>)
+                    } else if (amVar.r() is com.corrodinggames.rts.game.units.custom.l) {
+                        asVar.c(3)
+                        asVar.c((amVar.r() as com.corrodinggames.rts.game.units.custom.l).M)
+                    } else {
+                        throw IOException("Unhandled getUnitType on save:" + amVar.r().javaClass.toString())
+                    }
+                } else {
+                    asVar.c(2)
+                    if (wVar is com.corrodinggames.rts.game.l) {
+                        asVar.c(1)
+                    } else if (wVar is f) {
+                        asVar.c(2)
+                    } else if (wVar is com.corrodinggames.rts.gameFramework.d.f) {
+                        asVar.c(3)
+                    } else {
+                        val str: String = wVar::class.java.toString()
+                        throw IOException("Unhandled class on save: $str")
+                    }
+                }
+                asVar.a(wVar.eh)
+            }
+            asVar.d("Section: CurrentUnitId")
+            asVar.a(B.bX.z())
+            B.bV.a(asVar)
+            B.bS.a(asVar)
+            B.bY.a(asVar)
+            // 写入用户数据
+            for (i3 in 0 until n.c) {
+                val k2 = n.k(i3)
+                k2?.a(asVar)
+            }
+            asVar.e()
+            val it2: Iterator<*> = er.iterator()
+            while (it2.hasNext()) {
+                val wVar2: w = it2.next() as w
+                wVar2.a(asVar)
+                asVar.e()
+            }
+            asVar.a("saveCompression")
+            asVar.e()
+            asVar.c("<SAVE END>")
+        } catch (e: IOException) {
+            e.printStackTrace()
+            throw e
+        }
+
     }
 }

--- a/Server-Core/src/main/java/net/rwhps/server/plugin/beta/WinTestMain.kt
+++ b/Server-Core/src/main/java/net/rwhps/server/plugin/beta/WinTestMain.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020-2023 RW-HPS Team and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license that can be found through the following link.
+ *
+ * https://github.com/RW-HPS/RW-HPS/blob/master/LICENSE
+ */
+
+package net.rwhps.server.plugin.beta
+
+import net.rwhps.server.data.event.GameOverData
+import net.rwhps.server.data.global.Data
+import net.rwhps.server.data.plugin.PluginData
+import net.rwhps.server.plugin.Plugin
+import net.rwhps.server.plugin.event.AbstractEvent
+import net.rwhps.server.util.file.FileUtil
+
+class WinTestMain : Plugin() {
+    override fun registerEvents(): AbstractEvent? {
+        object: AbstractEvent {
+            override fun registerGameOverEvent(gameOverData: GameOverData?) {
+                if (gameOverData == null) {
+                    return
+                }
+
+
+                gameOverData.run {
+                    val data = PluginData()
+                    data.setFileUtil(FileUtil.getFolder(Data.Plugin_Data_Path).toFile("T.bin"))
+                    data.setData("All Player", allPlayerList)
+                    data.setData("Win Player", winPlayerList)
+                    data.setData("Map Name", mapName)
+                    data.setData("Player Data", playerData)
+                    data.setData("RePlay Size", FileUtil.getFolder(Data.Plugin_RePlays_Path).toFile(replayName).readFileByte())
+                    data.save()
+                }
+
+            }
+        }
+        return null
+    }
+}

--- a/Server-Core/src/main/java/net/rwhps/server/plugin/event/AbstractEvent.kt
+++ b/Server-Core/src/main/java/net/rwhps/server/plugin/event/AbstractEvent.kt
@@ -9,6 +9,7 @@
 
 package net.rwhps.server.plugin.event
 
+import net.rwhps.server.data.event.GameOverData
 import net.rwhps.server.data.player.Player
 
 interface AbstractEvent {
@@ -45,11 +46,9 @@ interface AbstractEvent {
 
     /** 开始游戏 [同步-ASync]  */
     fun registerGameStartEvent() { /* Optional use of plugins */ }
-    /** 无头开始游戏 [同步-Synchronization] */
-    fun registerHessStartEvent() { /* Optional use of plugins */ }
 
     /** 结束游戏 [同步-ASync]  */
-    fun registerGameOverEvent() { /* Optional use of plugins */ }
+    fun registerGameOverEvent(gameOverData: GameOverData?) { /* Optional use of plugins */ }
 
     /** 玩家被ban [异步-ASync]  */
     fun registerPlayerBanEvent(player: Player) { /* Optional use of plugins */ }

--- a/Server-Core/src/main/java/net/rwhps/server/util/file/FileUtil.kt
+++ b/Server-Core/src/main/java/net/rwhps/server/util/file/FileUtil.kt
@@ -343,7 +343,7 @@ open class FileUtil {
             val jarName = pathSplit[pathSplit.size - 1]
             val jarPath = path.replace(jarName, "")
 
-            setFilePath(decode(jarPath, "UTF-8"))
+            setFilePath(decode(jarPath, Data.UTF_8))
 		}
 
         /**
@@ -428,7 +428,7 @@ open class FileUtil {
 
         @JvmStatic
         fun getJarPath(): String {
-            return this::class.java.protectionDomain.codeSource.location.path
+            return decode(this::class.java.protectionDomain.codeSource.location.path, Data.UTF_8)
         }
 
         private fun cehckFolderPath(defPath:String, path: String): String {

--- a/Server-Core/src/main/java/net/rwhps/server/util/inline/Reflection.kt
+++ b/Server-Core/src/main/java/net/rwhps/server/util/inline/Reflection.kt
@@ -64,7 +64,13 @@ fun Class<*>.findField(name: String, type: Class<*>? = null): Field? {
  * @return Class<*>?
  */
 fun String.toClassAutoLoader(obj: Any): Class<*>? {
-    return this.toClass(obj.javaClass.classLoader)
+    return if (obj is Class<*>) {
+        this.toClass(obj.classLoader)
+    } else if (obj is ClassLoader) {
+        this.toClass(obj)
+    } else {
+        this.toClass(obj.javaClass.classLoader)
+    }
 }
 
 /**

--- a/Server-Core/src/main/java/net/rwhps/server/util/log/Log.kt
+++ b/Server-Core/src/main/java/net/rwhps/server/util/log/Log.kt
@@ -31,12 +31,12 @@ object Log {
     private val LOG_CACHE = StringBuilder()
 
     @JvmStatic
-    fun set(log: String) {
+	fun set(log: String) {
         LOG_GRADE = Logg.valueOf(log).getLogg()
     }
 
     @JvmStatic
-    fun setCopyPrint(system: Boolean) {
+	fun setCopyPrint(system: Boolean) {
         logPrint =
             if (system) {
                 { error:Boolean, text: String ->
@@ -59,7 +59,7 @@ object Log {
     }
 
     @JvmStatic
-    val logCache: String
+	val logCache: String
         get() {
             val result = LOG_CACHE.toString()
             LOG_CACHE.delete(0, LOG_CACHE.length)
@@ -110,7 +110,7 @@ object Log {
     }
 
     @JvmStatic
-    fun error(tag: Any, e: Any) {
+	fun error(tag: Any, e: Any) {
         logs(6, tag, e)
     }
 
@@ -127,7 +127,7 @@ object Log {
         logs(5, "WARN", e)
     }
     @JvmStatic
-    fun warn(tag: Any, e: Any) {
+	fun warn(tag: Any, e: Any) {
         logs(5, tag, e)
     }
 
@@ -144,7 +144,7 @@ object Log {
         logs(4, "INFO", e)
     }
     @JvmStatic
-    fun info(tag: Any, e: Any) {
+	fun info(tag: Any, e: Any) {
         logs(4, tag, e)
     }
 
@@ -161,7 +161,7 @@ object Log {
         logs(3, "DEBUG", e)
     }
     @JvmStatic
-    fun debug(tag: Any, e: Any) {
+	fun debug(tag: Any, e: Any) {
         logs(3, tag, e)
     }
 
@@ -198,7 +198,7 @@ object Log {
     }
 
     @JvmStatic
-    fun clog(text: String, vararg obj: Any?) {
+	fun clog(text: String, vararg obj: Any?) {
         clog(MessageFormat(text).format(obj))
     }
 


### PR DESCRIPTION
# Features
向 `GameOverEvent` 加入新数据传入, 可以通过这个得到胜负判定时刻玩家的状态和 `RePlay` 文件名
> 在手动Gameover的时候将传入null

Bytes可以被反序列化了


# Bug Fixes
玩家重连导致的服务器推出
游戏中的服务器退出
中文路径的报错
`toClassAutoLoader`传入 `Class` `ClassLoader` 导致的错误
玩家输赢判定
无法控制玩家

# Other Changes
[Core] 无头端的识别, 不依赖名字
[Core] 去除同步限制