### PR TITLE
支持ESM插件加载，移除了旧有的独立JS插件加载器

### DIFF
--- a/Server-Core/build.gradle.kts
+++ b/Server-Core/build.gradle.kts
@@ -56,6 +56,8 @@ dependencies {
 	api("it.unimi.dsi:fastutil-core:8.5.12")
 
 	implementation("org.graalvm.js:js:${properties["graalvm.version"]}")
+	implementation("com.google.jimfs:jimfs:1.2")
+
 
 	testApi("org.junit.jupiter:junit-jupiter-engine:5.9.2")
 }

--- a/Server-Core/src/main/java/net/rwhps/server/plugin/JavaScriptPlugin.kt
+++ b/Server-Core/src/main/java/net/rwhps/server/plugin/JavaScriptPlugin.kt
@@ -56,7 +56,7 @@ object JavaScriptPlugin {
         val defaults = cx.eval(
             Source.newBuilder("js", """
                 ${modules.joinToString("\n") { """
-                    export { main as ${it.getString("name")} } from '${it.getString("name")}/index.mjs'
+                    export { main as ${it.getString("name")} } from '${it.getString("name")}/${it.getString("main")}'
                 """.trimIndent() }}
             """.trimIndent(), "\$load.mjs")
                 .mimeType("application/javascript+module")

--- a/Server-Core/src/main/java/net/rwhps/server/plugin/JavaScriptPlugin.kt
+++ b/Server-Core/src/main/java/net/rwhps/server/plugin/JavaScriptPlugin.kt
@@ -47,6 +47,7 @@ object JavaScriptPlugin {
             .allowHostAccess(HostAccess.newBuilder()
                 .allowAllClassImplementations(true)
                 .allowAllImplementations(true)
+                .allowPublicAccess(true)
                 .build())
             .allowHostClassLookup { _ -> true }
             .fileSystem(fileSystem)

--- a/Server-Core/src/main/java/net/rwhps/server/plugin/JavaScriptPlugin.kt
+++ b/Server-Core/src/main/java/net/rwhps/server/plugin/JavaScriptPlugin.kt
@@ -52,6 +52,7 @@ object JavaScriptPlugin {
                     .build())
                 .allowHostClassLookup { _ -> true }
                 .fileSystem(fileSystem)
+                .currentWorkingDirectory(fileSystem.parsePath("/"))
                 .allowIO(true)
                 .build()
             cx.enter()

--- a/Server-Core/src/main/java/net/rwhps/server/plugin/JavaScriptPluginFileSystem.kt
+++ b/Server-Core/src/main/java/net/rwhps/server/plugin/JavaScriptPluginFileSystem.kt
@@ -104,7 +104,7 @@ class JavaScriptPluginFileSystem: FileSystem {
      */
     fun registerJavaPackage(name: String, main: Path) {
         //debug的时候用
-        //Log.clog("Registered Java package to esm:$name")
+        //net.rwhps.server.util.log.Log.clog("Registered Java package to esm:$name")
         javaMap[name] = main
     }
 
@@ -122,10 +122,13 @@ class JavaScriptPluginFileSystem: FileSystem {
     override fun parsePath(path: String?): Path {
         val parsedPath = if(path != null) {
             if(path.startsWith("../") || path.startsWith("./") || path.startsWith("/")) {
+                //完整路径
                 memoryFileSystem.getPath(path)
             } else if(path.startsWith("@")) {
+                //插件入口快捷方式
                 moduleMap[path.removePrefix("@")] ?: memoryFileSystem.getPath("/")
             } else if(path.startsWith("java:")) {
+                //java注入类型快捷访问方式
                 javaMap[path.removePrefix("java:")] ?: memoryFileSystem.getPath("/")
             } else {
                 memoryFileSystem.getPath("/").resolve(path)
@@ -172,6 +175,7 @@ class JavaScriptPluginFileSystem: FileSystem {
         attributes: String?,
         vararg options: LinkOption?
     ): MutableMap<String, Any> {
+        println("readAttributes $path")
         throw Exception("'delete(path: Path?)' not implemented")
     }
 }

--- a/Server-Core/src/main/java/net/rwhps/server/plugin/JavaScriptPluginFileSystem.kt
+++ b/Server-Core/src/main/java/net/rwhps/server/plugin/JavaScriptPluginFileSystem.kt
@@ -99,6 +99,7 @@ class JavaScriptPluginFileSystem: FileSystem {
      * @param main 模块入口文件
      */
     fun registerJavaPackage(name: String, main: Path) {
+        println("registered $name")
         javaMap[name] = main
     }
 
@@ -109,7 +110,9 @@ class JavaScriptPluginFileSystem: FileSystem {
         return memoryFileSystem.getPath(first, *more)
     }
 
-    override fun parsePath(uri: URI?): Path = memoryFileSystem.getPath(uri?.path ?: "/")
+    override fun parsePath(uri: URI?): Path {
+        return parsePath(uri?.toString())
+    }
 
     override fun parsePath(path: String?): Path {
         val parsedPath = if(path != null) {

--- a/Server-Core/src/main/java/net/rwhps/server/plugin/JavaScriptPluginFileSystem.kt
+++ b/Server-Core/src/main/java/net/rwhps/server/plugin/JavaScriptPluginFileSystem.kt
@@ -1,0 +1,131 @@
+package net.rwhps.server.plugin
+
+import com.google.common.jimfs.Configuration
+import com.google.common.jimfs.Jimfs
+import org.graalvm.polyglot.io.FileSystem
+import java.io.IOException
+import java.net.URI
+import java.nio.ByteBuffer
+import java.nio.channels.ClosedChannelException
+import java.nio.channels.SeekableByteChannel
+import java.nio.file.*
+import java.nio.file.attribute.FileAttribute
+
+class JavaScriptPluginFileSystem: FileSystem {
+
+    private val memoryFileSystem = Jimfs.newFileSystem(Configuration.unix())
+
+    private class ReadOnlySeekableByteArrayChannel(private val data: ByteArray): SeekableByteChannel {
+        var position = 0
+        var closed = false
+        override fun close() {
+            this.closed = true
+        }
+
+        override fun isOpen(): Boolean = !closed
+
+        override fun write(src: ByteBuffer?): Int {
+            throw UnsupportedOperationException()
+        }
+
+        override fun position(): Long {
+            return position.toLong()
+        }
+
+        @Throws(IOException::class)
+        override fun position(newPosition: Long): SeekableByteChannel {
+            ensureOpen()
+            position = Math.max(0, Math.min(newPosition, size())).toInt()
+            return this
+        }
+
+        override fun size(): Long {
+            return data.size.toLong()
+        }
+
+        @Throws(IOException::class)
+        override fun read(buf: ByteBuffer): Int {
+            ensureOpen()
+            val remaining = size().toInt() - position
+            if (remaining <= 0) {
+                return -1
+            }
+            var readBytes = buf.remaining()
+            if (readBytes > remaining) {
+                readBytes = remaining
+            }
+            buf.put(data, position, readBytes)
+            position += readBytes
+            return readBytes
+        }
+
+        override fun truncate(size: Long): SeekableByteChannel {
+            throw UnsupportedOperationException()
+        }
+
+
+        @Throws(ClosedChannelException::class)
+        private fun ensureOpen() {
+            if (!isOpen) {
+                throw ClosedChannelException()
+            }
+        }
+
+    }
+
+    fun getPath(first: String, vararg more: String?): Path = memoryFileSystem.getPath(first, *more)
+
+    override fun parsePath(uri: URI?): Path = memoryFileSystem.getPath(uri?.path ?: "/")
+
+    override fun parsePath(path: String?): Path {
+        val parsedPath = if(path != null) {
+            if(path.startsWith("../") || path.startsWith("./") || path.startsWith("/")) {
+                memoryFileSystem.getPath(path)
+            } else {
+                memoryFileSystem.getPath("/").resolve(path)
+            }
+        } else {
+            memoryFileSystem.getPath("/")
+        }
+        return parsedPath
+    }
+
+    override fun checkAccess(path: Path?, modes: MutableSet<out AccessMode>?, vararg linkOptions: LinkOption?) {
+    }
+
+    override fun createDirectory(dir: Path?, vararg attrs: FileAttribute<*>?) {
+        throw Exception("'createDirectory(dir: Path?, vararg attrs: FileAttribute<*>?)' not implemented")
+    }
+
+    override fun delete(path: Path?) {
+        throw Exception("'delete(path: Path?)' not implemented")
+    }
+
+    override fun newByteChannel(
+        path: Path?,
+        options: MutableSet<out OpenOption>?,
+        vararg attrs: FileAttribute<*>?
+    ): SeekableByteChannel {
+        return if(path != null) {
+            ReadOnlySeekableByteArrayChannel(Files.readAllBytes(path))
+        } else {
+            ReadOnlySeekableByteArrayChannel(ByteArray(0))
+        }
+    }
+
+    override fun newDirectoryStream(dir: Path?, filter: DirectoryStream.Filter<in Path>?): DirectoryStream<Path> {
+        throw Exception("'newDirectoryStream(dir: Path?, filter: DirectoryStream.Filter<in Path>?): DirectoryStream<Path>' not implemented")
+    }
+
+    override fun toAbsolutePath(path: Path?): Path = path?.toAbsolutePath() ?: memoryFileSystem.getPath("/")
+
+    override fun toRealPath(path: Path?, vararg linkOptions: LinkOption?): Path = path?.toRealPath() ?: memoryFileSystem.getPath("/")
+
+    override fun readAttributes(
+        path: Path?,
+        attributes: String?,
+        vararg options: LinkOption?
+    ): MutableMap<String, Any> {
+        throw Exception("'delete(path: Path?)' not implemented")
+    }
+}

--- a/Server-Core/src/main/java/net/rwhps/server/plugin/JavaScriptPluginFileSystem.kt
+++ b/Server-Core/src/main/java/net/rwhps/server/plugin/JavaScriptPluginFileSystem.kt
@@ -18,7 +18,11 @@ import java.nio.file.attribute.FileAttribute
  */
 class JavaScriptPluginFileSystem: FileSystem {
 
-    private val memoryFileSystem = Jimfs.newFileSystem(Configuration.unix())
+    private val memoryFileSystem = Jimfs.newFileSystem(
+        Configuration.unix()
+            .toBuilder()
+            .setWorkingDirectory("/")
+            .build())
     private val moduleMap: MutableMap<String, Path> = HashMap()
     private val javaMap: MutableMap<String, Path> = HashMap()
 
@@ -99,7 +103,8 @@ class JavaScriptPluginFileSystem: FileSystem {
      * @param main 模块入口文件
      */
     fun registerJavaPackage(name: String, main: Path) {
-        println("registered $name")
+        //debug的时候用
+        //Log.clog("Registered Java package to esm:$name")
         javaMap[name] = main
     }
 

--- a/Server-Core/src/main/java/net/rwhps/server/plugin/PluginsLoad.kt
+++ b/Server-Core/src/main/java/net/rwhps/server/plugin/PluginsLoad.kt
@@ -86,11 +86,10 @@ object PluginGlobalContext {
             jsFileSystem.getPath("/${json.getString("name")}/${json.getString("main")}")
         )
 
-        zip.getSpecifiedSuffixInThePackage(".mjs", true).forEach {
-            Files.write(modulePath.resolve(it.key), it.value)
-        }
-
-        zip.getSpecifiedSuffixInThePackage(".js", true).forEach {
+        zip.getZipAllBytes().forEach {
+            if(!(modulePath.resolve(it.key).parent.exists())) {
+                Files.createDirectories(modulePath.resolve(it.key).parent)
+            }
             Files.write(modulePath.resolve(it.key), it.value)
         }
     }

--- a/Server-Core/src/main/java/net/rwhps/server/plugin/PluginsLoad.kt
+++ b/Server-Core/src/main/java/net/rwhps/server/plugin/PluginsLoad.kt
@@ -35,6 +35,11 @@ object PluginGlobalContext {
             Files.createDirectory(modulePath)
         }
 
+        jsFileSystem.registerModule(
+            json.getString("name"),
+            jsFileSystem.getPath("/${json.getString("name")}/${json.getString("main")}")
+        )
+
         zip.getSpecifiedSuffixInThePackage(".mjs", true).forEach {
             Files.write(modulePath.resolve(it.key), it.value)
         }

--- a/Server-Core/src/main/java/net/rwhps/server/plugin/PluginsLoad.kt
+++ b/Server-Core/src/main/java/net/rwhps/server/plugin/PluginsLoad.kt
@@ -43,9 +43,10 @@ object PluginGlobalContext {
         val main = jsFileSystem.getPath("\$java/$packageName/index.mjs")
 
         if(!packagePath.exists()) {
-            Files.createDirectory(packagePath)
+            Files.createDirectories(packagePath)
             jsFileSystem.registerJavaPackage(packageName, main)
         }
+
         Files.write(
             main,
             "export const ${T::class.java.name.split(".").last()} = Java.type('${T::class.java.name}')\n"
@@ -98,6 +99,8 @@ class PluginsLoad {
         val dataImport = Seq<PluginImportData>()
 
         val jsModules = Seq<Json>()
+        PluginGlobalContext.injectJavaClass<Plugin>()
+        PluginGlobalContext.injectJavaClass<Log>()
 
         for (file in fileList) {
             val zip = CompressionDecoderUtils.zip(file)

--- a/Server-Core/src/main/java/net/rwhps/server/plugin/PluginsLoad.kt
+++ b/Server-Core/src/main/java/net/rwhps/server/plugin/PluginsLoad.kt
@@ -15,14 +15,29 @@ import net.rwhps.server.data.json.Json
 import net.rwhps.server.data.player.AbstractPlayer
 import net.rwhps.server.dependent.LibraryManager
 import net.rwhps.server.func.Cons
+import net.rwhps.server.func.Prov
+import net.rwhps.server.game.GameMaps
 import net.rwhps.server.game.GameUnitType
+import net.rwhps.server.game.simulation.core.AbstractPlayerData
+import net.rwhps.server.io.output.CompressOutputStream
+import net.rwhps.server.io.output.DisableSyncByteArrayOutputStream
+import net.rwhps.server.io.packet.Packet
+import net.rwhps.server.net.GroupNet
 import net.rwhps.server.net.core.ConnectionAgreement
+import net.rwhps.server.net.core.DataPermissionStatus
 import net.rwhps.server.net.core.IRwHps
+import net.rwhps.server.net.core.server.AbstractNetConnectServer
 import net.rwhps.server.plugin.event.AbstractEvent
 import net.rwhps.server.plugin.event.AbstractGlobalEvent
+import net.rwhps.server.struct.IntMap
+import net.rwhps.server.struct.ObjectMap
+import net.rwhps.server.struct.OrderedMap
 import net.rwhps.server.struct.Seq
+import net.rwhps.server.util.I18NBundle
 import net.rwhps.server.util.IsUtil
+import net.rwhps.server.util.PacketType
 import net.rwhps.server.util.compression.CompressionDecoderUtils
+import net.rwhps.server.util.compression.core.AbstractDecoder
 import net.rwhps.server.util.compression.core.CompressionDecoder
 import net.rwhps.server.util.file.FileUtil
 import net.rwhps.server.util.game.CommandHandler
@@ -34,9 +49,14 @@ import net.rwhps.server.util.log.Log
 import net.rwhps.server.util.log.Log.error
 import net.rwhps.server.util.log.Log.warn
 import java.io.File
+import java.io.FileOutputStream
+import java.io.InputStream
+import java.io.InputStreamReader
+import java.io.OutputStream
 import java.lang.reflect.InvocationTargetException
 import java.net.URLClassLoader
 import java.nio.file.*
+import java.util.Properties
 import kotlin.io.path.exists
 
 /**
@@ -120,6 +140,30 @@ object PluginGlobalContext {
         injectJavaClass<Command>("Command")
         injectJavaClass<CommandRunner<Any>>("CommandRunner")
         injectJavaClass<Cons<Any>>()
+        injectJavaClass<ObjectMap<Any, Any>>()
+        injectJavaClass<ObjectMap.Entry<Any, Any>>("ObjectMapEntry")
+        injectJavaClass<GroupNet>()
+        injectJavaClass<PacketType>()
+        injectJavaClass<Packet>()
+        injectJavaClass<IntMap<Any>>()
+        injectJavaClass<Prov<Any>>()
+        injectJavaClass<AbstractNetConnectServer>()
+        injectJavaClass<DataPermissionStatus.ServerStatus>("ServerStatus")
+        injectJavaClass<CompressOutputStream>()
+        injectJavaClass<DisableSyncByteArrayOutputStream>()
+        injectJavaClass<InputStream>()
+        injectJavaClass<OutputStream>()
+        injectJavaClass<AbstractPlayerData>()
+        injectJavaClass<I18NBundle>()
+        injectJavaClass<FileUtil>()
+        injectJavaClass<InputStreamReader>()
+        injectJavaClass<CompressionDecoder>()
+        injectJavaClass<AbstractDecoder>()
+        injectJavaClass<GameMaps.MapData>("MapData")
+        injectJavaClass<Properties>()
+        injectJavaClass<File>()
+        injectJavaClass<FileOutputStream>()
+        injectJavaClass<OrderedMap<Any, Any>>()
     }
 }
 

--- a/Server-Core/src/main/java/net/rwhps/server/plugin/PluginsLoad.kt
+++ b/Server-Core/src/main/java/net/rwhps/server/plugin/PluginsLoad.kt
@@ -19,9 +19,21 @@ import net.rwhps.server.util.file.FileUtil
 import net.rwhps.server.util.log.Log
 import net.rwhps.server.util.log.Log.error
 import net.rwhps.server.util.log.Log.warn
+import org.graalvm.polyglot.io.FileSystem
 import java.io.File
+import java.io.IOException
 import java.lang.reflect.InvocationTargetException
+import java.net.URI
 import java.net.URLClassLoader
+import java.nio.ByteBuffer
+import java.nio.channels.ClosedChannelException
+import java.nio.channels.SeekableByteChannel
+import java.nio.file.*
+import java.nio.file.attribute.FileAttribute
+
+object PluginGlobalContext {
+    val jsFileSystems = ArrayList<FileSystem>()
+}
 
 /**
  * 在这里完成 插件的加载
@@ -29,6 +41,9 @@ import java.net.URLClassLoader
  */
 class PluginsLoad {
     private fun loadPlugin(fileList: Seq<File>): Seq<PluginLoadData> {
+        val jsFileSystem = JavaScriptPluginFileSystem(HashMap())
+        PluginGlobalContext.jsFileSystems.add(jsFileSystem)
+
         val data = Seq<PluginLoadData>()
         val dataName = Seq<String>()
         val dataImport = Seq<PluginImportData>()
@@ -54,12 +69,16 @@ class PluginsLoad {
                 }
                 if (IsUtil.isBlank(json.getString("import"))) {
                     val mainPlugin = if (json.getString("main").endsWith("js",true)) {
+                        zip.getSpecifiedSuffixInThePackage(".mjs", true).forEach {
+                            jsFileSystem.addPath(Path.of(it.key), it.value)
+                        }
                         val mainJs = zip.getZipNameInputStream(json.getString("main"))
                         if (mainJs == null) {
+
                             error("Invalid JavaScriptPlugin Main", json.getString("main"))
                             continue
                         }
-                        JavaScriptPlugin.loadJavaScriptPlugin(FileUtil.readFileString(mainJs))
+                        JavaScriptPlugin.loadESMPlugin(json.getString("main"), FileUtil.readFileString(mainJs), jsFileSystem)
                     } else {
                         loadClass(file, json.getString("main"))
                     }
@@ -166,5 +185,130 @@ class PluginsLoad {
         internal fun addPluginClass(name: String,author: String,description: String, version: String, main: Plugin,mkdir: Boolean,skip: Boolean,list: Seq<PluginLoadData>) {
             list.add(PluginLoadData(name, author, description, version, main, mkdir , skip))
         }
+    }
+}
+
+class JavaScriptPluginFileSystem(
+    private val pathMap: MutableMap<Path, ByteArray>
+): FileSystem {
+    private class ReadOnlySeekableByteArrayChannel(private val data: ByteArray): SeekableByteChannel {
+        var position = 0
+        var closed = false
+        override fun close() {
+            this.closed = true
+        }
+
+        override fun isOpen(): Boolean = !closed
+
+        override fun write(src: ByteBuffer?): Int {
+            throw UnsupportedOperationException()
+        }
+
+        override fun position(): Long {
+            return position.toLong()
+        }
+
+        @Throws(IOException::class)
+        override fun position(newPosition: Long): SeekableByteChannel {
+            ensureOpen()
+            position = Math.max(0, Math.min(newPosition, size())).toInt()
+            return this
+        }
+
+        override fun size(): Long {
+            return data.size.toLong()
+        }
+
+        @Throws(IOException::class)
+        override fun read(buf: ByteBuffer): Int {
+            ensureOpen()
+            val remaining = size().toInt() - position
+            if (remaining <= 0) {
+                return -1
+            }
+            var readBytes = buf.remaining()
+            if (readBytes > remaining) {
+                readBytes = remaining
+            }
+            buf.put(data, position, readBytes)
+            position += readBytes
+            return readBytes
+        }
+
+        override fun truncate(size: Long): SeekableByteChannel {
+            throw UnsupportedOperationException()
+        }
+
+
+        @Throws(ClosedChannelException::class)
+        private fun ensureOpen() {
+            if (!isOpen) {
+                throw ClosedChannelException()
+            }
+        }
+
+    }
+    fun addPath(path: Path, arr: ByteArray) {
+        pathMap[path] = arr
+    }
+
+    override fun parsePath(uri: URI?): Path {
+        throw Exception("'parsePath(uri: URI?): Path' not implemented")
+    }
+
+    override fun parsePath(path: String?): Path {
+        return if(path != null) {
+            Path.of(path)
+        } else {
+            Path.of("")
+        }
+    }
+
+    override fun checkAccess(path: Path?, modes: MutableSet<out AccessMode>?, vararg linkOptions: LinkOption?) {
+    }
+
+    override fun createDirectory(dir: Path?, vararg attrs: FileAttribute<*>?) {
+        throw Exception("'createDirectory(dir: Path?, vararg attrs: FileAttribute<*>?)' not implemented")
+    }
+
+    override fun delete(path: Path?) {
+        throw Exception("'delete(path: Path?)' not implemented")
+    }
+
+    override fun newByteChannel(
+        path: Path?,
+        options: MutableSet<out OpenOption>?,
+        vararg attrs: FileAttribute<*>?
+    ): SeekableByteChannel {
+        return if(path != null) {
+            val res = pathMap.entries.find { it.key == path }
+            if(res != null) {
+                ReadOnlySeekableByteArrayChannel(res.value)
+            } else {
+                ReadOnlySeekableByteArrayChannel(ByteArray(0))
+            }
+        } else {
+            ReadOnlySeekableByteArrayChannel(ByteArray(0))
+        }
+    }
+
+    override fun newDirectoryStream(dir: Path?, filter: DirectoryStream.Filter<in Path>?): DirectoryStream<Path> {
+        throw Exception("'newDirectoryStream(dir: Path?, filter: DirectoryStream.Filter<in Path>?): DirectoryStream<Path>' not implemented")
+    }
+
+    override fun toAbsolutePath(path: Path?): Path {
+        return path ?: Path.of("")
+    }
+
+    override fun toRealPath(path: Path?, vararg linkOptions: LinkOption?): Path {
+        return path ?: Path.of("")
+    }
+
+    override fun readAttributes(
+        path: Path?,
+        attributes: String?,
+        vararg options: LinkOption?
+    ): MutableMap<String, Any> {
+        throw Exception("'delete(path: Path?)' not implemented")
     }
 }

--- a/Server-Core/src/main/java/net/rwhps/server/plugin/PluginsLoad.kt
+++ b/Server-Core/src/main/java/net/rwhps/server/plugin/PluginsLoad.kt
@@ -87,7 +87,7 @@ object PluginGlobalContext {
         )
 
         zip.getZipAllBytes().forEach {
-            if(!(modulePath.resolve(it.key).parent.exists())) {
+            if(!modulePath.resolve(it.key).parent.exists()) {
                 Files.createDirectories(modulePath.resolve(it.key).parent)
             }
             Files.write(modulePath.resolve(it.key), it.value)

--- a/Server-Core/src/main/java/net/rwhps/server/plugin/PluginsLoad.kt
+++ b/Server-Core/src/main/java/net/rwhps/server/plugin/PluginsLoad.kt
@@ -89,6 +89,10 @@ object PluginGlobalContext {
         zip.getSpecifiedSuffixInThePackage(".mjs", true).forEach {
             Files.write(modulePath.resolve(it.key), it.value)
         }
+
+        zip.getSpecifiedSuffixInThePackage(".js", true).forEach {
+            Files.write(modulePath.resolve(it.key), it.value)
+        }
     }
 
     /**

--- a/Server-Core/src/main/java/net/rwhps/server/plugin/PluginsLoad.kt
+++ b/Server-Core/src/main/java/net/rwhps/server/plugin/PluginsLoad.kt
@@ -103,7 +103,6 @@ object PluginGlobalContext {
     fun initJavaClasses() {
         injectJavaClass<Plugin>()
         injectJavaClass<Log>()
-        injectJavaClass<Properties>()
         injectJavaClass<AbstractEvent>()
         injectJavaClass<AbstractPlayer>()
         injectJavaClass<GameOverData>()

--- a/Server-Core/src/main/java/net/rwhps/server/plugin/PluginsLoad.kt
+++ b/Server-Core/src/main/java/net/rwhps/server/plugin/PluginsLoad.kt
@@ -14,6 +14,7 @@ import net.rwhps.server.data.global.Data
 import net.rwhps.server.data.json.Json
 import net.rwhps.server.data.player.AbstractPlayer
 import net.rwhps.server.dependent.LibraryManager
+import net.rwhps.server.func.Cons
 import net.rwhps.server.game.GameUnitType
 import net.rwhps.server.net.core.ConnectionAgreement
 import net.rwhps.server.net.core.IRwHps
@@ -36,7 +37,6 @@ import java.io.File
 import java.lang.reflect.InvocationTargetException
 import java.net.URLClassLoader
 import java.nio.file.*
-import java.util.Properties
 import kotlin.io.path.exists
 
 /**
@@ -116,6 +116,7 @@ object PluginGlobalContext {
         injectJavaClass<ResponseType>("ResponseType")
         injectJavaClass<Command>("Command")
         injectJavaClass<CommandRunner<Any>>("CommandRunner")
+        injectJavaClass<Cons<Any>>()
     }
 }
 


### PR DESCRIPTION
现在可以从插件包中加载多个插件，加载方式为ESM（ECMA Script模块）
所有JS脚本后缀名可以为mjs或js（暂不考虑支持cjs，commonjs模块）
插件入口文件在JSON的"main"字段指定，模块名由"name"字段指定。（暂定）
对插件入口模块的访问可通过"@pluginname"的形式进行。
注入了插件常用的类型，包括Log，可通过"java:the.package.path"访问其包并像正常esm一样引入包下已引入类型。
已知问题：由于GraalVM运行在主线程，如果脚本报错无法处理异常会导致服务器崩溃。