### PR TITLE
rwhps direct open fix

### DIFF
--- a/Server-Core/src/main/java/net/rwhps/server/Main.kt
+++ b/Server-Core/src/main/java/net/rwhps/server/Main.kt
@@ -42,7 +42,6 @@ import net.rwhps.server.data.bean.BeanRelayConfig
 import net.rwhps.server.data.bean.BeanServerConfig
 import net.rwhps.server.data.global.Data
 import net.rwhps.server.data.global.Data.privateReader
-import net.rwhps.server.data.global.NetStaticData
 import net.rwhps.server.data.plugin.PluginManage
 import net.rwhps.server.data.plugin.PluginManage.addGlobalEventManage
 import net.rwhps.server.data.plugin.PluginManage.init
@@ -57,7 +56,6 @@ import net.rwhps.server.game.event.global.ServerLoadEvent
 import net.rwhps.server.io.ConsoleStream
 import net.rwhps.server.io.output.DynamicPrintStream
 import net.rwhps.server.net.api.WebGetRelayInfo
-import net.rwhps.server.util.CLITools
 import net.rwhps.server.util.SystemSetProperty
 import net.rwhps.server.util.file.FileUtils.Companion.getFolder
 import net.rwhps.server.util.game.CommandHandler
@@ -72,6 +70,7 @@ import org.jline.terminal.TerminalBuilder
 import java.io.InterruptedIOException
 import java.util.logging.Level
 import java.util.logging.Logger
+import javax.swing.JOptionPane
 import kotlin.system.exitProcess
 
 
@@ -166,7 +165,8 @@ object Main {
      */
     private fun inputMonitorInit() {
         // 防止傻逼双击运行jar
-        if (System.`in` == null) {
+        if (System.console() == null) {
+            JOptionPane.showMessageDialog(null, "RW-HPS需要在终端运行,而不是直接打开\nYou should run RW-HPS in a terminal,not direct open", "ERROR", JOptionPane.ERROR_MESSAGE)
             Core.exit()
         }
 

--- a/Server-Core/src/main/java/net/rwhps/server/Main.kt
+++ b/Server-Core/src/main/java/net/rwhps/server/Main.kt
@@ -165,7 +165,7 @@ object Main {
      */
     private fun inputMonitorInit() {
         // 防止傻逼双击运行jar
-        if (System.console() == null) {
+        if (System.console() == null && System.getProperty("rwhps.forceRun") != "true") {
             JOptionPane.showMessageDialog(null, "RW-HPS需要在终端运行,而不是直接打开\nYou should run RW-HPS in a terminal,not direct open", "ERROR", JOptionPane.ERROR_MESSAGE)
             Core.exit()
         }


### PR DESCRIPTION
![image](https://github.com/RW-HPS/RW-HPS/assets/29498336/21c2a2a7-c9e0-473a-945e-a5858090a35e)
修复了可以直接打开jar的问题
由于是通过`System.console()`判断是否为控制台运行,但是IDEA并未使用控制台来运行jar程序,而是使用标准输入输出流(`System.in`/`out`)来访问程序的输入输出,因此无法通过此方法来判断是否为使用IDEA运行
所以在使用IDEA运行时需要加入JVM参数: `-Drwhps.forceRun=true`来解决